### PR TITLE
Add user management APIs

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -7,7 +7,7 @@
     "status": "Active",
     "releases": [
         {
-            "tagName": "v1.0.1",
+            "tagName": "v1.0.2",
             "products": [
                 "MI 4.3.0"
             ],

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>google.ads</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>WSO2 Carbon - Google Ads Connector</name>
     <url>https://wso2.com</url>

--- a/src/main/resources/functions/component.xml
+++ b/src/main/resources/functions/component.xml
@@ -67,5 +67,13 @@
             <file>campaignCriteriaMutate.xml</file>
             <description>Creates, updates, or removes criteria. Operation statuses are returned.</description>
         </component>
+        <component name="userListsMutate">
+            <file>userListsMutate.xml</file>
+            <description>Creates or updates user lists. Operation statuses are returned.</description>
+        </component>
+        <component name="uploadUserData">
+            <file>uploadUserData.xml</file>
+            <description>Uploads the given user data.</description>
+        </component>
     </subComponents>
 </component>

--- a/src/main/resources/functions/uploadUserData.xml
+++ b/src/main/resources/functions/uploadUserData.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~  WSO2 LLC. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+-->
+
+<!-- Generated on 20-Sun, 10, 2024 20:56:39+0530 -->
+
+<template xmlns="http://ws.apache.org/ns/synapse" name="uploadUserData">
+    <!-- Path Parameter List -->
+    <parameter name="customerId" description="Required. The ID of the customer for which to update the user data."/>
+    <!-- Request Body Parameter List -->
+    <parameter name="operations" description="Required. The list of operations to be done."/>
+    <parameter name="customerMatchUserListMetadata"
+               description="Metadata for data updates to a Customer Match user list."/>
+    <sequence>
+        <class name="org.wso2.carbon.google.ads.connector.RestURLBuilder">
+            <property name="operationPath" value="/v17/customers/{customerId}:uploadUserData"/>
+            <property name="pathParameters" value="customerId,"/>
+        </class>
+        <payloadFactory media-type="json" template-type="freemarker">
+            <format>
+                <![CDATA[{
+                                                                                        <#if (args.arg1)?has_content>
+                                    "operations": ${args.arg1},                                </#if>
+                                                                                            <#if (args.arg2)?has_content>
+                                    "customerMatchUserListMetadata": ${args.arg2}                                </#if>
+                                                                                        }]]>
+            </format>
+            <args>
+                <arg evaluator="xml" expression="$func:operations"/>
+                <arg evaluator="xml" expression="$func:customerMatchUserListMetadata"/>
+            </args>
+        </payloadFactory>
+        <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" value="application/json" scope="axis2"/>
+        <property name="ContentType" value="application/json" scope="axis2"/>
+        <header name="Accept" value="application/json" scope="transport" action="set"/>
+        <call>
+            <endpoint>
+                <http method="POST" uri-template="{uri.var.base}{+uri.var.urlPath}{+uri.var.urlQuery}"/>
+            </endpoint>
+        </call>
+        <!-- Remove custom header information -->
+        <header name="request-id" scope="transport" action="remove"/>
+        <header name="x-xss-protection" scope="transport" action="remove"/>
+        <header name="vary" scope="transport" action="remove"/>
+        <header name="alt-svc" scope="transport" action="remove"/>
+        <header name="server" scope="transport" action="remove"/>
+        <header name="access-control-allow-origin" scope="transport" action="remove"/>
+        <header name="access-control-allow-methods" scope="transport" action="remove"/>
+        <header name="x-content-type-options" scope="transport" action="remove"/>
+        <header name="access-control-allow-headers" scope="transport" action="remove"/>
+        <header name="x-frame-options" scope="transport" action="remove"/>
+        <header name="cache-control" scope="transport" action="remove"/>
+    </sequence>
+</template>

--- a/src/main/resources/functions/userListsMutate.xml
+++ b/src/main/resources/functions/userListsMutate.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~  WSO2 LLC. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+-->
+
+<!-- Generated on 20-Sun, 10, 2024 20:56:39+0530 -->
+
+<template xmlns="http://ws.apache.org/ns/synapse" name="userListsMutate">
+    <!-- Path Parameter List -->
+    <parameter name="customerId" description="Required. The ID of the customer whose user lists are being modified."/>
+    <!-- Request Body Parameter List -->
+    <parameter name="operations"
+               description="Required. The list of operations to perform on individual user lists."/>
+    <parameter name="partialFailure"
+               description="If true, successful operations will be carried out and invalid operations will return errors. If false, all operations will be carried out in one transaction if and only if they are all valid. Default is false."/>
+    <parameter name="validateOnly"
+               description="If true, the request is validated but not executed. Only errors are returned, not results."/>
+    <sequence>
+        <class name="org.wso2.carbon.google.ads.connector.RestURLBuilder">
+            <property name="operationPath" value="/v17/customers/{customerId}/userLists:mutate"/>
+            <property name="pathParameters" value="customerId,"/>
+        </class>
+        <payloadFactory media-type="json" template-type="freemarker">
+            <format>
+                <![CDATA[{
+                                                                                        <#if (args.arg1)?has_content>
+                                    "operations": ${args.arg1},                                </#if>
+                                                                                            <#if (args.arg2)?has_content>
+                                    "partialFailure": "${args.arg2}",                                </#if>
+                                                                                            <#if (args.arg3)?has_content>
+                                    "validateOnly": "${args.arg3}"                                </#if>
+                                                                                        }]]>
+            </format>
+            <args>
+                <arg evaluator="xml" expression="$func:operations"/>
+                <arg evaluator="xml" expression="$func:partialFailure"/>
+                <arg evaluator="xml" expression="$func:validateOnly"/>
+            </args>
+        </payloadFactory>
+        <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" value="application/json" scope="axis2"/>
+        <property name="ContentType" value="application/json" scope="axis2"/>
+        <header name="Accept" value="application/json" scope="transport" action="set"/>
+        <call>
+            <endpoint>
+                <http method="POST" uri-template="{uri.var.base}{+uri.var.urlPath}{+uri.var.urlQuery}"/>
+            </endpoint>
+        </call>
+        <!-- Remove custom header information -->
+        <header name="request-id" scope="transport" action="remove"/>
+        <header name="x-xss-protection" scope="transport" action="remove"/>
+        <header name="vary" scope="transport" action="remove"/>
+        <header name="alt-svc" scope="transport" action="remove"/>
+        <header name="server" scope="transport" action="remove"/>
+        <header name="access-control-allow-origin" scope="transport" action="remove"/>
+        <header name="access-control-allow-methods" scope="transport" action="remove"/>
+        <header name="x-content-type-options" scope="transport" action="remove"/>
+        <header name="access-control-allow-headers" scope="transport" action="remove"/>
+        <header name="x-frame-options" scope="transport" action="remove"/>
+        <header name="cache-control" scope="transport" action="remove"/>
+    </sequence>
+</template>

--- a/src/main/resources/uischema/uploadUserData.json
+++ b/src/main/resources/uischema/uploadUserData.json
@@ -1,0 +1,72 @@
+{
+  "connectorName": "googleAds",
+  "operationName": "uploadUserData",
+  "title": "Customers Upload User Data",
+  "help": "Uploads the given user data..",
+  "elements": [
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "General",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "configRef",
+              "displayName": "Connection",
+              "inputType": "connection",
+              "allowedConnectionTypes": [
+                "googleAds"
+              ],
+              "defaultType": "connection.googleAds",
+              "defaultValue": "",
+              "required": "true",
+              "helpTip": "Connection to be used"
+            }
+          },
+          {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "Parameters",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "customerId",
+                    "displayName": "Customer Id",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "Required. The ID of the customer for which to update the user data."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "operations",
+                    "displayName": "Operations",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "The list of operations to perform on individual ads."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "customerMatchUserListMetadata",
+                    "displayName": "Customer Match User List Metadata",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Metadata for data updates to a Customer Match user list."
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/uischema/userListsMutate.json
+++ b/src/main/resources/uischema/userListsMutate.json
@@ -1,0 +1,83 @@
+{
+  "connectorName": "googleAds",
+  "operationName": "userListsMutate",
+  "title": "Customers User Lists Mutate",
+  "help": "Creates or updates user lists. Operation statuses are returned.",
+  "elements": [
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "General",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "configRef",
+              "displayName": "Connection",
+              "inputType": "connection",
+              "allowedConnectionTypes": [
+                "googleAds"
+              ],
+              "defaultType": "connection.googleAds",
+              "defaultValue": "",
+              "required": "true",
+              "helpTip": "Connection to be used"
+            }
+          },
+          {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "Parameters",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "customerId",
+                    "displayName": "Customer Id",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "Required. The ID of the customer whose user lists are being modified."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "operations",
+                    "displayName": "Operations",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "Required. The list of operations to perform on individual user lists. Type: object (UserListOperation)"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "partialFailure",
+                    "displayName": "Partial Failure",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "If true, successful operations will be carried out and invalid operations will return errors. If false, all operations will be carried out in one transaction if and only if they are all valid. Default is false."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "validateOnly",
+                    "displayName": "Validate Only",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "If true, the request is validated but not executed. Only errors are returned, not results."
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
$title

## APIs Added
**1. Create userlist to add the users - customers.userLists.mutate** : https://developers.google.com/google-ads/api/rest/reference/rest/v17/customers.userLists/mutate 
**2. Add users to userlist - customers.uploadUserData** : https://developers.google.com/google-ads/api/rest/reference/rest/v17/customers/uploadUserData#UserDataOperation

## Tested 
> If the email count added is less than 100 it won't be processed fast. Also you won't be allowed to add 100 emails at once, all I could add was 20 at once. So to add 100 you have to call the API 5 times. 

**Response for too many records:**
```json
{
    "error": {
        "code": 400,
        "message": "Request contains an invalid argument.",
        "status": "INVALID_ARGUMENT",
        "details": [
            {
                "@type": "type.googleapis.com/google.ads.googleads.v17.errors.GoogleAdsFailure",
                "errors": [
                    {
                        "errorCode": {
                            "userDataError": "TOO_MANY_USER_IDENTIFIERS"
                        },
                        "message": "Maximum number of user identifiers allowed for each request is 100 and for each operation is 20.",
                        "location": {
                            "fieldPathElements": [
                                {
                                    "fieldName": "operations",
                                    "index": 0
                                },
                                {
                                    "fieldName": "create"
                                }
                            ]
                        }
                    }
                ],
                "requestId": "XAyewqoBY3qPpCitgo5WwQ"
            }
        ]
    }
}
```
<img width="1373" alt="Screenshot 2024-10-20 at 21 30 09" src="https://github.com/user-attachments/assets/2f958f6c-6da0-4e0c-93c7-f459d0388436">
