### PR TITLE
Add MI 4.5.0 to products list

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -14,7 +14,8 @@
         {
             "tagName": "v2.0.0",
             "products": [
-                "MI 4.4.0"
+                "MI 4.4.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {
@@ -1094,7 +1095,8 @@
         {
             "tagName": "v2.0.0",
             "products": [
-                "MI 4.4.0"
+                "MI 4.4.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {
@@ -1195,7 +1197,8 @@
             "tagName": "v1.1.0",
             "products": [
                 "MI 4.4.0",
-                "MI 4.3.0"
+                "MI 4.3.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {


### PR DESCRIPTION
This PR adds MI 4.5.0 to the products list for releases that already contain MI 4.4.0, ensuring compatibility with the new Micro Integrator version.